### PR TITLE
Remove getTestSystem() from HtmlTranslator.

### DIFF
--- a/src/fitnesse/testrunner/WikiTestPage.java
+++ b/src/fitnesse/testrunner/WikiTestPage.java
@@ -49,8 +49,7 @@ public class WikiTestPage implements TestPage {
     String content = getDecoratedContent();
     ParsingPage parsingPage = new ParsingPage(new WikiSourcePage(sourcePage), variableSource);
     Symbol syntaxTree = Parser.make(parsingPage, content).parse();
-    return new HtmlTranslator(parsingPage.getPage(), parsingPage, 
-            sourcePage.getVariable(WikiPageIdentity.TEST_SYSTEM)).translateTree(syntaxTree);
+    return new HtmlTranslator(parsingPage.getPage(), parsingPage).translateTree(syntaxTree);
   }
 
   @Override

--- a/src/fitnesse/wikitext/parser/ColoredSlimTable.java
+++ b/src/fitnesse/wikitext/parser/ColoredSlimTable.java
@@ -126,11 +126,11 @@ public class ColoredSlimTable extends SymbolTypeDecorator{
     }
 
     public SymbolType isApplicable(Translator translator){
-        String testSystem = null;
+        Maybe<String> testSystem = Maybe.noString;
         if(translator instanceof HtmlTranslator){
-            testSystem = ((HtmlTranslator)translator).getTestSystem();
+            testSystem = ((HtmlTranslator) translator).getParsingPage().findVariable("TEST_SYSTEM");
         }
-        if(testSystem == null || !testSystem.equals("slim")){
+        if(testSystem.isNothing() || !testSystem.getValue().equals("slim")){
             return baseSymbolType;
         }
         return this;

--- a/src/fitnesse/wikitext/parser/HtmlTranslator.java
+++ b/src/fitnesse/wikitext/parser/HtmlTranslator.java
@@ -3,7 +3,6 @@ package fitnesse.wikitext.parser;
 public class HtmlTranslator extends Translator {
 
     private ParsingPage parsingPage;
-    private String testSystem;
 
     @Override
     protected Translation getTranslation(SymbolType symbolType) {
@@ -16,15 +15,8 @@ public class HtmlTranslator extends Translator {
 
     public ParsingPage getParsingPage() { return parsingPage; }
 
-    public String getTestSystem() { return testSystem; }
-
     public HtmlTranslator(SourcePage currentPage, ParsingPage parsingPage) {
-        this(currentPage, parsingPage, "fit");
-    }
-
-    public HtmlTranslator(SourcePage currentPage, ParsingPage parsingPage, String testSystem) {
         super(currentPage);
         this.parsingPage = parsingPage;
-        this.testSystem = testSystem;
     }
 }


### PR DESCRIPTION
I think it's nicer if the wikitext api's know nothing about test systems
